### PR TITLE
Experiment: Use Alpine Linux instead 🌱 

### DIFF
--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -1,22 +1,20 @@
 # syntax = docker/dockerfile:1.3
 
 # ---
-# 1. Use Debian stable (11, bullseye) version of PHP
-FROM php:8.0.26-fpm-bullseye AS base
+# 1. Use Alpine Linux version of PHP
+FROM php:8.0.26-fpm-alpine AS base
 
 # ---
 # 2. Upgrade system and installed dependencies for security patches
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/var/log \
     set -eux; \
-    apt-get update; \
-    apt-get upgrade -y
+    apk update; \
+    apk upgrade
 
 # ---
 # 3. Install PHP extensions
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/var/log \
     set -eux; \
     # ---

--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -1,22 +1,20 @@
 # syntax = docker/dockerfile:1.3
 
 # ---
-# 1. Use Debian stable (11, bullseye) version of PHP
-FROM php:8.1.13-fpm-bullseye AS base
+# 1. Use Alpine Linux version of PHP
+FROM php:8.1.13-fpm-alpine AS base
 
 # ---
 # 2. Upgrade system and installed dependencies for security patches
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/var/log \
     set -eux; \
-    apt-get update; \
-    apt-get upgrade -y
+    apk update; \
+    apk upgrade
 
 # ---
 # 3. Install PHP extensions
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/var/log \
     set -eux; \
     # ---

--- a/docker/8.2/Dockerfile
+++ b/docker/8.2/Dockerfile
@@ -1,22 +1,20 @@
 # syntax = docker/dockerfile:1.3
 
 # ---
-# 1. Use Debian stable (11, bullseye) version of PHP
-FROM php:8.2.0-fpm-bullseye AS base
+# 1. Use Alpine Linux version of PHP
+FROM php:8.2.0-fpm-alpine AS base
 
 # ---
 # 2. Upgrade system and installed dependencies for security patches
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/var/log \
     set -eux; \
-    apt-get update; \
-    apt-get upgrade -y
+    apk update; \
+    apk upgrade
 
 # ---
 # 3. Install PHP extensions
-RUN --mount=type=cache,target=/var/cache/apt \
-    --mount=type=cache,target=/var/lib/apt \
+RUN --mount=type=cache,target=/var/cache/apk \
     --mount=type=tmpfs,target=/var/log \
     set -eux; \
     # ---


### PR DESCRIPTION
Quick test of switching to Alpine Linux now that iconv issues for PHP have been solved ([PR#240 for docker/php](https://github.com/docker-library/php/issues/240))

This switch shows great savings on image size:

```
$ docker image ls
REPOSITORY                       TAG         SIZE
ghcr.io/luislavena/greek-steam   8.0-alpine  120MB
ghcr.io/luislavena/greek-steam   8.0         455MB
```